### PR TITLE
Fix wrong usage of "isset" instead of "defined"

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -225,7 +225,7 @@ $table_prefix = TABLE_PREFIX;
 setlocale(LC_ALL, WPLANG);
 
 // For compatibility with old plugins
-if (isset(WP_PLUGIN_DIR)) define( 'PLUGINDIR',  WP_PLUGIN_DIR );
+if (defined('WP_PLUGIN_DIR')) define( 'PLUGINDIR',  WP_PLUGIN_DIR );
 
 /** Absolute path to WordPress. */
 if ( !defined('ABSPATH') )


### PR DESCRIPTION
Some servers will return 500 error, other will pass without validating it.

To check if a "constant" is set developers must use the function "defined" (and NOT "isset", as it should be only used to determine if a "variable" is set and is not NULL).

References: http://php.net/manual/en/function.defined.php and http://php.net/manual/en/function.isset.php